### PR TITLE
Improve header scroll performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,11 +160,11 @@
         <div style="width:100vw; height:300vh;"></div>
     </main>
 </body>
-<script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
-<script src="js/animations.js"></script>
-<script src="js/main.js"></script>
-<script src="https://kit.fontawesome.com/8f446d19ac.js" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/lenis@1.3.4/dist/lenis.min.js" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js" defer></script>
+<script src="js/animations.js" defer></script>
+<script src="js/main.js" defer></script>
+<script src="https://kit.fontawesome.com/8f446d19ac.js" crossorigin="anonymous" defer></script>
 
 </html>

--- a/js/animations.js
+++ b/js/animations.js
@@ -1,10 +1,11 @@
+const header = document.querySelector(".header");
+const menu = document.querySelector(".header__links");
+
 if (window.scrollY > window.innerHeight - window.innerWidth * 4 / 100) {
-  document.querySelector(".header").classList.remove("on-top")
+  header.classList.remove("on-top");
 }
 
 const toggleMenu = () => {
-  const menu = document.querySelector(".header__links");
-  const header = document.querySelector(".header");
   const btnToggle = document.getElementById("menuToggle");
 
   // Переключаем классы меню
@@ -37,26 +38,36 @@ const toggleMenu = () => {
 };
 
 
-window.addEventListener("scroll", () => {
-  const header = document.querySelector(".header")
-  const menu = document.querySelector(".header__links")
+const handleScroll = () => {
   if (window.scrollY > window.innerHeight - window.innerWidth * 4 / 100) {
-    header.classList.remove("on-top")
-    header.style.top = 0
-  }
-  else {
-    header.classList.add("on-top")
-
+    header.classList.remove("on-top");
+    header.style.top = 0;
+  } else {
+    header.classList.add("on-top");
     if (menu.classList.contains("header__links--open")) {
-      header.style.top = 0
-      header.style.paddingTop = "calc(var(--offset) * 2)"
-      header.style.backgroundColor = "white"
-    }
-    else {
-      header.style.top = "calc(var(--offset) * 2 - var(--offset) * 0.5)"
+      header.style.top = 0;
+      header.style.paddingTop = "calc(var(--offset) * 2)";
+      header.style.backgroundColor = "white";
+    } else {
+      header.style.top = "calc(var(--offset) * 2 - var(--offset) * 0.5)";
     }
   }
-})
+};
+
+let scrollTick = false;
+window.addEventListener(
+  "scroll",
+  () => {
+    if (!scrollTick) {
+      scrollTick = true;
+      requestAnimationFrame(() => {
+        handleScroll();
+        scrollTick = false;
+      });
+    }
+  },
+  { passive: true }
+);
 window.addEventListener('load', () => {
   const tl = gsap.timeline({
     defaults: { ease: "power3.out" }


### PR DESCRIPTION
## Summary
- load JS files with `defer` so they don't block HTML parsing
- throttle header scroll handler and reuse DOM lookups for smoother scrolling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68666ee3ec3083238a6e7867d76022d6